### PR TITLE
Add hints to mercury

### DIFF
--- a/startup/22-dxp.py
+++ b/startup/22-dxp.py
@@ -1,7 +1,9 @@
 from ophyd.mca import (EpicsMCA, EpicsDXP, Mercury1, SoftDXPTrigger)
 
 class AMXMercury(Mercury1, SoftDXPTrigger):
-    pass
+    @property
+    def hints(self):
+        return {'fields': [self.mca.rois.roi0.count.name]}
 
 mercury = AMXMercury('XF:17IDB-ES:AMX{Det:Mer}', name='mercury')
 mercury.read_attrs = ['mca.spectrum', 'mca.preset_live_time', 'mca.rois.roi0.count',


### PR DESCRIPTION
Added hints to mercury device, so that BestEffortCallback can use the specified fields only.

Attn: @tacaswell @jskinner53 